### PR TITLE
feat: add fallback metric discovery via label values API

### DIFF
--- a/.github/workflows/release-fork.yaml
+++ b/.github/workflows/release-fork.yaml
@@ -1,0 +1,85 @@
+name: Release ndc-prometheus (fork)
+on:
+  push:
+    tags:
+      - "v*"
+
+env:
+  DOCKER_REGISTRY: ghcr.io
+  DOCKER_IMAGE_NAME: machanirobotics-labs/ndc-prometheus
+
+jobs:
+  release-image:
+    name: Build and push ndc-prometheus image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.DOCKER_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: docker-metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}
+
+      - name: Build and push docker image
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: ${{ steps.docker-metadata.outputs.tags }}
+          labels: ${{ steps.docker-metadata.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+
+  build-cli-binaries:
+    name: Build the CLI binaries
+    runs-on: ubuntu-latest
+    needs: [release-image]
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+
+      - name: Build the CLI
+        run: |
+          VERSION="$GITHUB_REF_NAME" make ci-build-configuration
+          mkdir release
+          .github/scripts/plugin-manifest.sh
+          mv _output/* release
+
+      - uses: actions/upload-artifact@v4
+        with:
+          path: release/ndc-prometheus-*
+          if-no-files-found: error
+          name: artifact
+
+      - name: Get version from tag
+        id: get-version
+        run: |
+          echo "tagged_version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+      - name: Create a draft release
+        uses: ncipollo/release-action@v1
+        with:
+          draft: true
+          tag: ${{ steps.get-version.outputs.tagged_version }}
+          artifacts: release/*

--- a/configuration/update_test.go
+++ b/configuration/update_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hasura/ndc-prometheus/connector/metadata"
+	"github.com/prometheus/common/model"
 	"gotest.tools/v3/assert"
 )
 
@@ -117,6 +118,77 @@ func TestNativeQueryVariables(t *testing.T) {
 			query, err := uc.formatNativeQueryVariables(tc.Input.Query, tc.ExpectedArguments)
 			assert.NilError(t, err)
 			assert.Equal(t, query, tc.ExpectedQuery)
+		})
+	}
+}
+
+func TestInferMetricType(t *testing.T) {
+	testCases := []struct {
+		Name     string
+		Expected model.MetricType
+	}{
+		{"http_requests_total", model.MetricTypeCounter},
+		{"wellness_tick_session_completed_total", model.MetricTypeCounter},
+		{"traces_spanmetrics_latency_bucket", model.MetricTypeHistogram},
+		{"http_request_duration_seconds_bucket", model.MetricTypeHistogram},
+		{"http_request_duration_seconds_sum", model.MetricTypeGauge},
+		{"http_request_duration_seconds_count", model.MetricTypeGauge},
+		{"target_info", model.MetricTypeGauge},
+		{"process_cpu_seconds_created", model.MetricTypeGauge},
+		{"go_goroutines", model.MetricTypeGauge},
+		{"temperature_celsius", model.MetricTypeGauge},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			result := inferMetricType(tc.Name)
+			assert.Equal(t, result, tc.Expected)
+		})
+	}
+}
+
+func TestIsHistogramSubMetric(t *testing.T) {
+	testCases := []struct {
+		Name     string
+		NameSet  map[string]bool
+		Expected bool
+	}{
+		{
+			Name:     "http_duration_sum",
+			NameSet:  map[string]bool{"http_duration_bucket": true, "http_duration_sum": true, "http_duration_count": true},
+			Expected: true,
+		},
+		{
+			Name:     "http_duration_count",
+			NameSet:  map[string]bool{"http_duration_bucket": true, "http_duration_sum": true, "http_duration_count": true},
+			Expected: true,
+		},
+		{
+			Name:     "http_duration_bucket",
+			NameSet:  map[string]bool{"http_duration_bucket": true, "http_duration_sum": true, "http_duration_count": true},
+			Expected: false,
+		},
+		{
+			Name:     "standalone_sum",
+			NameSet:  map[string]bool{"standalone_sum": true},
+			Expected: false,
+		},
+		{
+			Name:     "standalone_count",
+			NameSet:  map[string]bool{"standalone_count": true},
+			Expected: false,
+		},
+		{
+			Name:     "http_requests_total",
+			NameSet:  map[string]bool{"http_requests_total": true},
+			Expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			result := isHistogramSubMetric(tc.Name, tc.NameSet)
+			assert.Equal(t, result, tc.Expected)
 		})
 	}
 }

--- a/connector/client/labels.go
+++ b/connector/client/labels.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
 )
 
 // LabelNames return a list of [label names]
@@ -59,4 +60,58 @@ func (c *Client) LabelNames(
 	err = json.Unmarshal(body, &labelNames)
 
 	return labelNames, w, err
+}
+
+// GetLabelValues return a list of [label values] for a given label name.
+// This method uses a direct HTTP GET request (like LabelNames) to support
+// additional parameters such as match[] filters and limits.
+//
+// [label values]: https://prometheus.io/docs/prometheus/latest/querying/api/#querying-label-values
+func (c *Client) GetLabelValues(
+	ctx context.Context,
+	label string,
+	matches []string,
+	startTime, endTime time.Time,
+	limit uint64,
+) (model.LabelValues, v1.Warnings, error) {
+	endpoint := c.client.URL("/api/v1/label/"+label+"/values", nil)
+	q := endpoint.Query()
+
+	for _, m := range matches {
+		if m == "" {
+			continue
+		}
+
+		q.Add("match[]", m)
+	}
+
+	if !startTime.IsZero() {
+		q.Set("start", formatTime(startTime))
+	}
+
+	if !endTime.IsZero() {
+		q.Set("end", formatTime(endTime))
+	}
+
+	if limit > 0 {
+		q.Set("limit", strconv.FormatUint(limit, 10))
+	}
+
+	endpoint.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	body, w, err := c.do(ctx, req)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var labelValues model.LabelValues
+
+	err = json.Unmarshal(body, &labelValues)
+
+	return labelValues, w, err
 }


### PR DESCRIPTION
Add fallback mechanism to discover metrics using /api/v1/label/__name__/values when /api/v1/metadata returns empty results (common with remote-write sources like OpenTelemetry Collector). Infer metric types from naming conventions (_total for counters, _bucket for histograms, etc.) and automatically filter histogram sub-metrics. Add GetLabelValues client method with support for match[] filters and limits.