### PR TITLE
ci: re-enable trivy vulnerability scanning with SHA-pinned action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -79,12 +79,12 @@ jobs:
           interval: 10
           retries: 8
 
-#       - name: Upload Trivy report as artifact
-#         uses: actions/upload-artifact@v4
-#         with:
-#           name: trivy-report
-#           path: /tmp/trivy-report-*.json
-# 
+      - name: Upload Trivy report as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-report
+          path: /tmp/trivy-report-*.json
+
       - name: Push docker image
         uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
Re-enable Trivy scanning by reverting the changes from PR #33. Pin trivy-action to `ed142fd0673e97e23eac54620cfb913e5ce36c25` (v0.36.0) for security.

Note: this repository does not currently contain any direct `aquasecurity/trivy-action` references, so the code change is limited to restoring the Trivy report artifact upload step from #33.

Co-authored-by: Poojan Savani <poojan@hasura.io>