### PR TITLE
ci: upgrade github actions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+        uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: ./go.mod
       - name: Install dependencies
@@ -28,8 +28,6 @@ jobs:
       - name: Vet
         run: go vet ./...
       - name: Lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           version: latest
-          only-new-issues: true
-          skip-cache: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,23 +17,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: [tests]
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up containerd
-        uses: crazy-max/ghaction-setup-containerd@v3
-
-      - name: Fix containerd socket permissions
-        run: |
-          sudo chgrp docker /run/containerd/containerd.sock
+      - name: Checkout
+        uses: actions/checkout@v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.DOCKER_REGISTRY }}
           username: ${{ github.actor }}
@@ -41,52 +35,12 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: docker-metadata
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }}
 
-      - name: Build image
-        uses: docker/build-push-action@v6
-        with:
-          push: false
-          tags: ${{ steps.docker-metadata.outputs.tags }}
-          labels: ${{ steps.docker-metadata.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
-          # Export the image to a tar so it can be imported into containerd so gokakashi can scan it
-          outputs: type=oci,dest=/tmp/image.tar
-
-      - name: Import docker image into containerd store
-        run: |
-          ctr images import --base-name ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_IMAGE_NAME }} --digests --all-platforms /tmp/image.tar
-
-      - name: Get first docker tag for gokakashi
-        id: first-docker-tag
-        run: |
-          FIRST_TAG=$(echo "${{ steps.docker-metadata.outputs.tags }}" | head -n 1)
-          echo "First docker tag: $FIRST_TAG"
-          echo "tag=$FIRST_TAG" >> $GITHUB_OUTPUT
-
-      - name: Scan docker image with gokakashi
-        uses: shinobistack/gokakashi-action@v0.1.1
-        with:
-          image: ${{ steps.first-docker-tag.outputs.tag }}
-          labels: agentKey=${{ github.run_id }}
-          policy: ci-platform
-          server: https://gokakashi-server.hasura-app.io
-          token: ${{ secrets.GOKAKASHI_API_TOKEN }}
-          cf_client_id: ${{ secrets.CF_ACCESS_CLIENT_ID }}
-          cf_client_secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
-          interval: 10
-          retries: 8
-
-      - name: Upload Trivy report as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: trivy-report
-          path: /tmp/trivy-report-*.json
-
       - name: Push docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           push: true
           tags: ${{ steps.docker-metadata.outputs.tags }}
@@ -99,8 +53,8 @@ jobs:
     needs: [release-image]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+        uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: "go.mod"
 
@@ -111,13 +65,13 @@ jobs:
           .github/scripts/plugin-manifest.sh
           mv _output/* release
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           path: release/manifest.yaml
           if-no-files-found: error
           name: plugin-manifest
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           path: release/ndc-prometheus-*
           if-no-files-found: error

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,8 +20,8 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+        uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: "go.mod"
       - name: Go unit tests


### PR DESCRIPTION
This pull request updates the CI configuration to use the latest major versions of GitHub Actions and related tools, and removes the container scanning steps from the release workflow. These changes help keep the workflows up-to-date, improve reliability, and simplify the release process.

**Dependency updates in GitHub Actions workflows:**

* Updated `actions/checkout` to v6 and `actions/setup-go` to v6 in `.github/workflows/lint.yaml`, `.github/workflows/release.yaml`, and `.github/workflows/test.yaml` for improved performance and compatibility. [[1]](diffhunk://#diff-4b122024a3a28ded65da76a2f1bface1f3a27328374438d1298d25585fe0603bL18-R19) [[2]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL102-R57) [[3]](diffhunk://#diff-245392b692a50c38ecab4381b118862db514035c10983f3bd4f4b7f1f4be4692L23-R24)
* Updated `golangci/golangci-lint-action` to v9 in `.github/workflows/lint.yaml`.
* Updated Docker-related actions to their latest major versions (`docker/setup-qemu-action@v4`, `docker/setup-buildx-action@v4`, `docker/login-action@v4`, `docker/metadata-action@v6`, `docker/build-push-action@v7`) in `.github/workflows/release.yaml`.
* Updated `actions/upload-artifact` to v7 in `.github/workflows/release.yaml`.

**Workflow simplification:**

* Removed container scanning steps (`crazy-max/ghaction-setup-containerd`, image import, `shinobistack/gokakashi-action`, and Trivy report upload) from the release workflow, streamlining the release process.