### PR TITLE
chore(images): migrate base images to private -stable aliases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build context at repo root: docker build -f Dockerfile .
-FROM golang:1.26 AS builder
+FROM us-docker.pkg.dev/hasura-container-images/external-images/docker.io/library/golang:1.26-stable AS builder
 
 WORKDIR /app
 COPY go.mod go.sum ./


### PR DESCRIPTION
## What

Re-homes base images to Hasura's private Artifact Registry `us-docker.pkg.dev/hasura-container-images/external-images` via floating `-stable` aliases. The `-stable` aliases auto-advance to the latest patched digest within the same version line, so this keeps the same version while satisfying the policy that all containers deployed in Hasura infra are pulled from the private registry rather than upstream registries.

## Exact FROM swaps

### `Dockerfile`
- `FROM golang:1.26` → `FROM us-docker.pkg.dev/hasura-container-images/external-images/docker.io/library/golang:1.26-stable`

## Notes

- This is part of an org-wide Phase 1 migration: **exact-match swaps only**. No version bumps, no reformatting, no other lines touched.
- The `gcr.io/distroless/static-debian13:nonroot` stage was intentionally left unchanged — it is not part of this scoped swap list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)